### PR TITLE
Feat#34: 어제 한 일 조회 기능 구현

### DIFF
--- a/src/main/java/server/poptato/todo/api/TodoController.java
+++ b/src/main/java/server/poptato/todo/api/TodoController.java
@@ -9,6 +9,7 @@ import server.poptato.todo.api.request.SwipeRequestDto;
 import server.poptato.todo.application.TodoService;
 import server.poptato.todo.application.response.BacklogListResponseDto;
 import server.poptato.todo.application.response.PaginatedHistoryResponseDto;
+import server.poptato.todo.application.response.PaginatedYesterdayResponseDto;
 import server.poptato.todo.application.response.TodayListResponseDto;
 import server.poptato.user.resolver.UserId;
 
@@ -68,5 +69,14 @@ public class TodoController {
                                     @Validated @RequestBody DragAndDropRequestDto dragAndDropRequestDto){
         todoService.dragAndDrop(userId, dragAndDropRequestDto);
         return new BaseResponse<>();
+    }
+    @GetMapping("/yesterdays")
+    public BaseResponse<PaginatedYesterdayResponseDto> getYesterdays(
+            @UserId Long userId,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "15") int size) {
+
+        PaginatedYesterdayResponseDto response = todoService.getYesterdays(userId, page, size);
+        return new BaseResponse<>(response);
     }
 }

--- a/src/main/java/server/poptato/todo/api/TodoController.java
+++ b/src/main/java/server/poptato/todo/api/TodoController.java
@@ -59,7 +59,6 @@ public class TodoController {
             @UserId Long userId,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "15") int size) {
-        System.out.println(userId);
         PaginatedHistoryResponseDto response = todoService.getHistories(userId, page, size);
 
         return new BaseResponse<>(response);

--- a/src/main/java/server/poptato/todo/application/TodoService.java
+++ b/src/main/java/server/poptato/todo/application/TodoService.java
@@ -140,7 +140,7 @@ public class TodoService {
     }
     public PaginatedYesterdayResponseDto getYesterdays(Long userId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<Todo> todosPage = todoRepository.findByUserIdAndTypeAndTodayStatus(Type.YESTERDAY, TodayStatus.INCOMPLETE, pageable);
+        Page<Todo> todosPage = todoRepository.findByUserIdAndTypeAndTodayStatus(userId, Type.YESTERDAY, TodayStatus.INCOMPLETE, pageable);
 
         List<YesterdayResponseDto> yesterdays = todosPage.getContent().stream()
                 .map(todo -> new YesterdayResponseDto(

--- a/src/main/java/server/poptato/todo/application/response/PaginatedYesterdayResponseDto.java
+++ b/src/main/java/server/poptato/todo/application/response/PaginatedYesterdayResponseDto.java
@@ -1,0 +1,15 @@
+package server.poptato.todo.application.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PaginatedYesterdayResponseDto {
+    private List<YesterdayResponseDto> yesterdays;
+    private int totalPageCount;
+}

--- a/src/main/java/server/poptato/todo/application/response/YesterdayResponseDto.java
+++ b/src/main/java/server/poptato/todo/application/response/YesterdayResponseDto.java
@@ -1,0 +1,13 @@
+package server.poptato.todo.application.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class YesterdayResponseDto {
+    private Long todoId;
+    private String content;
+}

--- a/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
+++ b/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
@@ -2,7 +2,6 @@ package server.poptato.todo.domain.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.Query;
 import server.poptato.todo.domain.entity.Todo;
 import server.poptato.todo.domain.value.TodayStatus;
 import server.poptato.todo.domain.value.Type;
@@ -29,5 +28,5 @@ public interface TodoRepository {
     List<Todo> findByIdIn(List<Long> ids);
     int findMaxBacklogOrderByIdIn(List<Long> ids);
     int findMaxTodayOrderByIdIn(List<Long> ids);
-    Page<Todo> findByTypeAndTodayStatus(Type type, TodayStatus todayStatus, Pageable pageable);
+    Page<Todo> findByUserIdAndTypeAndTodayStatus(Type type, TodayStatus todayStatus, Pageable pageable);
 }

--- a/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
+++ b/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
@@ -28,5 +28,5 @@ public interface TodoRepository {
     List<Todo> findByIdIn(List<Long> ids);
     int findMaxBacklogOrderByIdIn(List<Long> ids);
     int findMaxTodayOrderByIdIn(List<Long> ids);
-    Page<Todo> findByUserIdAndTypeAndTodayStatus(Type type, TodayStatus todayStatus, Pageable pageable);
+    Page<Todo> findByUserIdAndTypeAndTodayStatus(Long userId, Type type, TodayStatus todayStatus, Pageable pageable);
 }

--- a/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
+++ b/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
@@ -29,4 +29,5 @@ public interface TodoRepository {
     List<Todo> findByIdIn(List<Long> ids);
     int findMaxBacklogOrderByIdIn(List<Long> ids);
     int findMaxTodayOrderByIdIn(List<Long> ids);
+    Page<Todo> findByTypeAndTodayStatus(Type type, TodayStatus todayStatus, Pageable pageable);
 }

--- a/src/test/java/server/poptato/todo/api/TodoControllerTest.java
+++ b/src/test/java/server/poptato/todo/api/TodoControllerTest.java
@@ -269,4 +269,26 @@ public class TodoControllerTest {
                 .andExpect(status().isOk())
                 .andDo(print());
     }
+    @DisplayName("어제 한 일 조회 시 Query String에 기본값이 적용되고, JWT로 사용자 아이디를 조회한다.")
+    @Test
+    void 어제한일_쿼리스트링_기본값() throws Exception {
+        // when
+        mockMvc.perform(get("/yesterdays")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        verify(todoService).getYesterdays(1L, 0, 15);
+    }
+
+    @DisplayName("어제 한 일 조회 시 헤더에 JWT가 없으면 예외가 발생한다.")
+    @Test
+    void 어제한일_JWT_예외() throws Exception {
+        // when
+        mockMvc.perform(get("/yesterdays")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())  // JWT가 없으므로 400 Bad Request 응답
+                .andDo(print());
+    }
 }

--- a/src/test/java/server/poptato/todo/application/TodoServiceTest.java
+++ b/src/test/java/server/poptato/todo/application/TodoServiceTest.java
@@ -4,8 +4,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Pageable;
 import server.poptato.todo.api.request.DragAndDropRequestDto;
 import server.poptato.todo.application.response.PaginatedHistoryResponseDto;
+import server.poptato.todo.application.response.PaginatedYesterdayResponseDto;
 import server.poptato.todo.application.response.TodayListResponseDto;
 import server.poptato.todo.application.response.TodayResponseDto;
 import server.poptato.todo.domain.repository.TodoRepository;
@@ -348,5 +350,23 @@ class TodoServiceTest {
 
         // 전체 페이지 수가 적절하게 계산되었는지 확인
         assertThat(result.getTotalPageCount()).isGreaterThan(0);
+    }
+    @Test
+    @DisplayName("YESTERDAY 타입과 INCOMPLETE 상태인 todo 목록을 페이징 처리하여 가져온다")
+    void getYesterdays_ShouldReturnPagedResult() {
+        // given
+        Long userId = 1L;
+        int page = 0;
+        int size = 5; // 한번에 5개의 todo 가져오기
+
+
+        // when
+        PaginatedYesterdayResponseDto result = todoService.getYesterdays(userId, page, size);
+
+        // then
+        assertThat(result.getYesterdays()).hasSizeLessThanOrEqualTo(size); // 페이징 크기만큼 가져옴
+        assertThat(result.getTotalPageCount()).isGreaterThan(0);  // 총 페이지 수가 0보다 큼
+        assertThat(result.getYesterdays().get(0).getTodoId()).isNotNull(); // 첫 번째 todo의 ID가 null이 아님
+        assertThat(result.getYesterdays().get(0).getContent()).isNotNull(); // 첫 번째 todo의 내용이 null이 아님
     }
 }


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt)#13: Add JWT Token For Authorization
--> 

Resolves #{이슈-번호}
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->
Resolves #34 
## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
-  userId 랑 YESTERDAY, INCOMPLETE 를 페이징을 통해 불러옵니다

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- 
![image](https://github.com/user-attachments/assets/3f4924ac-3430-4508-bccd-1d01d11b090c)


### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- 
