### PR TITLE
Fix: 백로그 조회 시 마감기한이 항상 null로 조회되는 문제 해결

### DIFF
--- a/src/main/java/server/poptato/todo/application/response/BacklogResponseDto.java
+++ b/src/main/java/server/poptato/todo/application/response/BacklogResponseDto.java
@@ -19,12 +19,9 @@ public class BacklogResponseDto {
         this.content = todo.getContent();
         this.isBookmark = todo.isBookmark();
         this.deadline = todo.getDeadline();
-
-        if (todo.getDeadline() != null && todo.getTodayDate() != null) {
-            this.dDay = (int) ChronoUnit.DAYS.between(todo.getTodayDate(), todo.getDeadline());
-        } else {
-            // 마감 기한을 계산할 수 없는 경우 NULL
-            this.deadline = null;
-        }
+        LocalDate todayDate = LocalDate.now();
+        if (this.deadline==null)
+            this.dDay = null;
+        else this.dDay = (int) ChronoUnit.DAYS.between(todayDate, todo.getDeadline());
     }
 }


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt)#13: Add JWT Token For Authorization
--> 

Resolves #없음
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- 백로그 조회 시 마감기한이 항상 null로 조회되는 문제 해결
  - BacklogResponseDto 생성자 코드에서 항상 null 로 대입하고 있었다. 

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- 

### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- 
