### PR TITLE
Fix: 투데이/백로그 조회 시 데이터가 없을 경우 예외가 아닌 빈 리스트 반환으로 수정

### DIFF
--- a/src/main/java/server/poptato/todo/application/TodoService.java
+++ b/src/main/java/server/poptato/todo/application/TodoService.java
@@ -53,14 +53,22 @@ public class TodoService {
                     userId, Type.TODAY, todayDate, TodayStatus.COMPLETED);
         todays.addAll(completedTodos);
 
-        // 전체 리스트에서 페이징
-        int start = (page) * size;
-        int end = Math.min(start + size, todays.size());
-        if (start >= end) throw new TodoException(TodoExceptionErrorCode.INVALID_PAGE);
+        List<Todo> todaySubList;
+        int totalPageCount;
 
-        List<Todo> todaySubList = todays.subList(start, end);
-        int totalPageCount = (int) Math.ceil((double) todays.size() / size);
+        if(todays.size()==0) {
+            totalPageCount = 0;
+            todaySubList = new ArrayList<>();
+        }
+        else{
+            // 전체 리스트에서 페이징
+            int start = (page) * size;
+            int end = Math.min(start + size, todays.size());
+            if (start >= end) throw new TodoException(TodoExceptionErrorCode.INVALID_PAGE);
 
+            todaySubList = todays.subList(start, end);
+            totalPageCount = (int) Math.ceil((double) todays.size() / size);
+        }
         return TodayListResponseDto.builder()
                 .date(todayDate)
                 .todays(todaySubList)

--- a/src/main/java/server/poptato/todo/application/TodoService.java
+++ b/src/main/java/server/poptato/todo/application/TodoService.java
@@ -53,22 +53,15 @@ public class TodoService {
                     userId, Type.TODAY, todayDate, TodayStatus.COMPLETED);
         todays.addAll(completedTodos);
 
+        // 전체 리스트에서 페이징
+        int start = (page) * size;
+        int end = Math.min(start + size, todays.size());
         List<Todo> todaySubList;
-        int totalPageCount;
+        if (start >= end) todaySubList = new ArrayList<>();
+        else todaySubList = todays.subList(start, end);
 
-        if(todays.size()==0) {
-            totalPageCount = 0;
-            todaySubList = new ArrayList<>();
-        }
-        else{
-            // 전체 리스트에서 페이징
-            int start = (page) * size;
-            int end = Math.min(start + size, todays.size());
-            if (start >= end) throw new TodoException(TodoExceptionErrorCode.INVALID_PAGE);
+        int totalPageCount = (int) Math.ceil((double) todays.size() / size);
 
-            todaySubList = todays.subList(start, end);
-            totalPageCount = (int) Math.ceil((double) todays.size() / size);
-        }
         return TodayListResponseDto.builder()
                 .date(todayDate)
                 .todays(todaySubList)

--- a/src/test/java/server/poptato/todo/application/TodoServiceTest.java
+++ b/src/test/java/server/poptato/todo/application/TodoServiceTest.java
@@ -63,11 +63,40 @@ class TodoServiceTest {
         Long userId = 1L;
         int page = 2;
         int size = 8;
-        LocalDate todayDate = LocalDate.now();
+        LocalDate todayDate = LocalDate.of(2024,10,16);
         //when & then
         assertThatThrownBy(()-> todoService.getTodayList(userId,page,size,todayDate))
                 .isInstanceOf(TodoException.class)
                 .hasMessage(TodoExceptionErrorCode.INVALID_PAGE.getMessage());
+    }
+
+    @DisplayName("투데이_데이터가 없는 경우 null을 반환한다.")
+    @Test
+    void 투데이_데이터_수_0개_응답(){
+        //given
+        Long userId = 50L;
+        int page = 0;
+        int size = 8;
+        LocalDate todayDate = LocalDate.now();
+        //when 
+        TodayListResponseDto todayList = todoService.getTodayList(userId, page, size, todayDate);
+        //then
+        assertThat(todayList.getTodays()).isEmpty();
+        assertThat(todayList.getTotalPageCount()).isEqualTo(0);
+    }
+
+    @DisplayName("백로그_데이터가 없는 경우 null을 반환한다.")
+    @Test
+    void 백로그_데이터_수_0개_응답(){
+        //given
+        Long userId = 50L;
+        int page = 0;
+        int size = 8;
+        //when
+        BacklogListResponseDto backlogList = todoService.getBacklogList(userId, page, size);
+        //then
+        assertThat(backlogList.getBacklogs()).isEmpty();
+        assertThat(backlogList.getTotalPageCount()).isEqualTo(0);
     }
 
     @DisplayName("투데이 목록 조회 시, 미달성 투데이가 먼저 조회되고, 그 다음 달성 투데이가 조회된다.")

--- a/src/test/java/server/poptato/todo/application/TodoServiceTest.java
+++ b/src/test/java/server/poptato/todo/application/TodoServiceTest.java
@@ -56,21 +56,21 @@ class TodoServiceTest {
         assertThat(todoService.getTodayList(userId,page,size,todayDate).getTodays().size()).isEqualTo(size);
     }
 
-    @DisplayName("유효하지 않는 페이지 수일 경우 예외가 발생한다.")
+    @DisplayName("유효하지 않는 페이지 수일 경우 빈 리스트를 반환한다.")
     @Test
-    void 유효하지_않은_페이지_수_예외(){
+    void 유효하지_않은_페이지_수_응답(){
         //given
         Long userId = 1L;
         int page = 2;
         int size = 8;
         LocalDate todayDate = LocalDate.of(2024,10,16);
-        //when & then
-        assertThatThrownBy(()-> todoService.getTodayList(userId,page,size,todayDate))
-                .isInstanceOf(TodoException.class)
-                .hasMessage(TodoExceptionErrorCode.INVALID_PAGE.getMessage());
+        //when
+        TodayListResponseDto todayList = todoService.getTodayList(userId, page, size, todayDate);
+        //then
+        assertThat(todayList.getTodays()).isEmpty();
     }
 
-    @DisplayName("투데이_데이터가 없는 경우 null을 반환한다.")
+    @DisplayName("투데이_데이터가 없는 경우 빈 리스트를 반환한다.")
     @Test
     void 투데이_데이터_수_0개_응답(){
         //given
@@ -85,7 +85,7 @@ class TodoServiceTest {
         assertThat(todayList.getTotalPageCount()).isEqualTo(0);
     }
 
-    @DisplayName("백로그_데이터가 없는 경우 null을 반환한다.")
+    @DisplayName("백로그_데이터가 없는 경우 빈 리스트를 반환한다.")
     @Test
     void 백로그_데이터_수_0개_응답(){
         //given


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt)#13: Add JWT Token For Authorization
--> 

Resolves #없음
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- 데이터가 없는 경우에는 항상 빈 리스트로 반환됩니다.
- 유효하지 않은 페이지 예외를 제거하였습니다.

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- 

### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- 
